### PR TITLE
Tidy up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,9 @@ RUN make linux
 #--------------------------#
 FROM debian:buster-slim AS dependencies
 
-RUN apt-get update                                                               \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    bash                                                                         \
-    ca-certificates                                                              \
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install --assume-yes --no-install-recommends \
+    bash                                                                                          \
+    ca-certificates                                                                               \
     curl
 
 # bash 4 required for `pipefail`
@@ -97,8 +96,8 @@ FROM debian:buster-slim AS docker-gcloud-sdk
 
 ENV CLOUD_SDK_VERSION 189.0.0
 
-RUN apt-get update                                                               \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt update &&                                 \
+      apt install --assume-yes --no-install-recommends                           \
       apt-transport-https                                                        \
       awscli                                                                     \
       bash                                                                       \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN curl -sLo /dependencies/kustomize                                           
 #--------------------------#
 # docker-gcloud-sdk        #
 #--------------------------#
-FROM debian:buster AS docker-gcloud-sdk
+FROM debian:buster-slim AS docker-gcloud-sdk
 
 ENV CLOUD_SDK_VERSION 189.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,24 @@ RUN set -euxo pipefail; curl -sL "https://github.com/instrumenta/conftest/releas
   | tar -xz                                                                                                                                                        \
   && mv conftest /dependencies/
 
+# Install jq
+ARG JQ_VERSION=1.5
+RUN curl -sLo /dependencies/jq                                                     \
+    "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" \
+  && chmod +x /dependencies/jq
+
+# Install yq
+ARG YQ_VERSION=2.1.1
+RUN curl -sLo /dependencies/yq                                                       \
+    "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+  && chmod +x /dependencies/yq
+
+# Install kustomize
+ARG KUSTOMIZE_VERSION=2.0.2
+RUN curl -sLo /dependencies/kustomize                                                                   \
+    "https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64" \
+  && chmod +x /dependencies/kustomize
+
 #--------------------------#
 # docker-gcloud-sdk        #
 #--------------------------#
@@ -83,6 +101,7 @@ RUN apt-get update                                                              
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       apt-transport-https                                                        \
       awscli                                                                     \
+      bash                                                                       \
       bzip2                                                                      \
       ca-certificates                                                            \
       curl                                                                       \
@@ -117,14 +136,6 @@ RUN apt-get update                                                              
                                                                                  \
   && rm -rf /var/lib/apt/lists/*                                                 \
                                                                                  \
-  && curl https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -Lo /usr/local/bin/jq                                                                                  \
-  && chmod +x /usr/local/bin/jq                                                  \
-                                                                                 \
-  && curl https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_amd64 -Lo /usr/local/bin/yq \
-  && chmod +x /usr/local/bin/yq                                                  \
-                                                                                 \
-  && curl https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.2/kustomize_2.0.2_linux_amd64 -Lo /usr/local/bin/kustomize  \
-  && chmod +x /usr/local/bin/kustomize                                              \
                                                                                     \
   && gcloud config set core/disable_usage_reporting true                            \
   && gcloud config set component_manager/disable_update_check true                  \
@@ -160,5 +171,8 @@ RUN gcloud --version                \
     && notary help                  \
     && docker-compose version       \
     && goss help                    \
-    && conftest --version
+    && conftest --version           \
+    && jq --version                 \
+    && yq --version                 \
+    && kustomize version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,86 +1,92 @@
+#--------------------------#
+# Docker                   #
+#--------------------------#
 FROM docker:18.09.2 AS static-docker-source
 
-# ---
+#--------------------------#
+# Golang Builder           #
+#--------------------------#
 
 FROM golang:1.12 AS builder
 
+ENV GOPATH /go
 RUN go get github.com/OJ/gobuster
 WORKDIR /go/src/github.com/OJ/gobuster
 RUN make linux
 
-# ---
+#--------------------------#
+# docker-gcloud-sdk        #
+#--------------------------#
 
-FROM debian:buster
+FROM debian:buster AS docker-gcloud-sdk
 
 ENV CLOUD_SDK_VERSION 189.0.0
 
-RUN \
-  DEBIAN_FRONTEND=noninteractive \
-    apt update && apt install --assume-yes --no-install-recommends \
-      apt-transport-https \
-      awscli \
-      bzip2 \
-      ca-certificates \
-      curl \
-      dnsutils \
-      gawk \
-      gettext-base \
-      git \
-      gnupg \
-      golang \
-      lsb-release \
-      lsof \
-      make \
-      nmap \
-      nmap-common \
-      ncat \
-      openssh-client \
-      parallel \
-      postgresql-client \
-      rsync \
-      wget \
-      xmlstarlet \
-  \
-  && export CLOUD_SDK_REPO \
-  && CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
+RUN apt-get update                                                               \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      apt-transport-https                                                        \
+      awscli                                                                     \
+      bzip2                                                                      \
+      ca-certificates                                                            \
+      curl                                                                       \
+      dnsutils                                                                   \
+      gawk                                                                       \
+      gettext-base                                                               \
+      git                                                                        \
+      gnupg                                                                      \
+      golang                                                                     \
+      lsb-release                                                                \
+      lsof                                                                       \
+      make                                                                       \
+      nmap                                                                       \
+      nmap-common                                                                \
+      ncat                                                                       \
+      openssh-client                                                             \
+      parallel                                                                   \
+      postgresql-client                                                          \
+      rsync                                                                      \
+      wget                                                                       \
+      xmlstarlet                                                                 \
+                                                                                 \
+  && export CLOUD_SDK_REPO                                                       \
+  && CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"                             \
   && echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
   && bash -euxo pipefail -c "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - " \
-  \
-  && DEBIAN_FRONTEND=noninteractive \
-       apt update && apt install --assume-yes --no-install-recommends \
-         google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \
-         kubectl \
-  \
-  && rm -rf /var/lib/apt/lists/* \
-  \
-  && curl https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -Lo /usr/local/bin/jq \
-  && chmod +x /usr/local/bin/jq \
-  \
+                                                                                 \
+  && DEBIAN_FRONTEND=noninteractive                                              \
+       apt update && apt install --assume-yes --no-install-recommends            \
+         google-cloud-sdk=${CLOUD_SDK_VERSION}-0                                 \
+         kubectl                                                                 \
+                                                                                 \
+  && rm -rf /var/lib/apt/lists/*                                                 \
+                                                                                 \
+  && curl https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -Lo /usr/local/bin/jq                                                                                  \
+  && chmod +x /usr/local/bin/jq                                                  \
+                                                                                 \
   && curl https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_amd64 -Lo /usr/local/bin/yq \
-  && chmod +x /usr/local/bin/yq \
-  \
-  && curl https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.2/kustomize_2.0.2_linux_amd64 -Lo /usr/local/bin/kustomize \
-  && chmod +x /usr/local/bin/kustomize \
-  \
-   && \
-  gcloud config set core/disable_usage_reporting true && \
-  gcloud config set component_manager/disable_update_check true && \
-  gcloud config set metrics/environment github_docker_image && \
-  ssh-keyscan -H github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts && \
-  useradd -u 1000 -ms /bin/bash jenkins
+  && chmod +x /usr/local/bin/yq                                                  \
+                                                                                 \
+  && curl https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.2/kustomize_2.0.2_linux_amd64 -Lo /usr/local/bin/kustomize  \
+  && chmod +x /usr/local/bin/kustomize                                              \
+                                                                                    \
+  && gcloud config set core/disable_usage_reporting true                            \
+  && gcloud config set component_manager/disable_update_check true                  \
+  && gcloud config set metrics/environment github_docker_image                      \
+  && ssh-keyscan -H github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts \
+  && useradd -u 1000 -ms /bin/bash jenkins
 
 # bats-core
-RUN cd /opt/ \
-  && git clone https://github.com/bats-core/bats-core.git \
-  && cd bats-core/ \
+RUN cd /opt/                                               \
+  && git clone https://github.com/bats-core/bats-core.git  \
+  && cd bats-core/                                         \
   && git checkout 8789f910812afbf6b87dd371ee5ae30592f1423f \
-  && ./install.sh /usr/local \
+  && ./install.sh /usr/local                               \
   && bats --version
 
 # doctl (Digital Ocean CLI)
-RUN cd $(mktemp -d) \
+RUN cd $(mktemp -d)           \
   && curl -sL https://github.com/digitalocean/doctl/releases/download/v1.13.0/doctl-1.13.0-linux-amd64.tar.gz \
-    | tar -xzv \
+    | tar -xzv                \
   && mv doctl /usr/local/bin/ \
   && doctl version
 
@@ -90,30 +96,30 @@ SHELL ["/bin/bash", "-c"]
 # github hub (git subcmomand for PR workflows)
 RUN set -euxo pipefail; cd /opt/ \
   && curl -L https://github.com/github/hub/releases/download/v2.6.0/hub-linux-amd64-2.6.0.tgz \
-  | tar xzvf - \
+  | tar xzvf -                   \
   && ./hub-linux-amd64-*/install \
   && hub --version
 
 # AWS IAM authenticator for EKS
-RUN curl -o /usr/local/bin/aws-iam-authenticator \
+RUN curl -o /usr/local/bin/aws-iam-authenticator   \
     https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator \
   && chmod +x /usr/local/bin/aws-iam-authenticator \
   && aws-iam-authenticator help
 
 # notary
-RUN curl -Lo /usr/local/bin/notary \
+RUN curl -Lo /usr/local/bin/notary  \
     https://github.com/theupdateframework/notary/releases/download/v0.6.1/notary-Linux-amd64 \
   && chmod +x /usr/local/bin/notary \
   && notary help
 
 # docker-compose
 RUN curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" \
-      -o /usr/local/bin/docker-compose \
+      -o /usr/local/bin/docker-compose        \
     && chmod +x /usr/local/bin/docker-compose \
     && docker-compose version
 
 # goss
-RUN curl -Lo /usr/local/bin/goss \
+RUN curl -Lo /usr/local/bin/goss  \
     https://github.com/aelsabbahy/goss/releases/download/v0.3.7/goss-linux-amd64 \
   && chmod +x /usr/local/bin/goss \
   && goss help
@@ -121,7 +127,7 @@ RUN curl -Lo /usr/local/bin/goss \
 # conftest
 RUN wget https://github.com/instrumenta/conftest/releases/download/v0.4.2/conftest_0.4.2_Linux_x86_64.tar.gz \
   && tar xzf conftest_0.4.2_Linux_x86_64.tar.gz \
-  && mv conftest /usr/local/bin \
+  && mv conftest /usr/local/bin                 \
   && conftest --version
 
 # docker
@@ -130,7 +136,6 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 # gobuster
 COPY --from=builder /go/src/github.com/OJ/gobuster/build/gobuster-linux-amd64/gobuster /usr/local/bin/
 
-RUN \
-    gcloud --version \
+RUN gcloud --version    \
     && docker --version \
     && kubectl version --client

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,7 @@ RUN apt-get update                                                              
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     bash                                                                         \
     ca-certificates                                                              \
-    curl                                                                         \
-    git                                                                          \
-    unzip                                                                        \
-    wget
+    curl
 
 # bash 4 required for `pipefail`
 SHELL ["/bin/bash", "-c"]
@@ -35,46 +32,44 @@ WORKDIR /downloads
 
 # Install doctl (Digital Ocean CLI)
 ARG DOCTL_VERSION=1.13.0
-RUN cd $(mktemp -d)           \
-  && curl -sL https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz \
-    | tar -xzv                \
+RUN set -euxo pipefail; curl -sL "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz" \
+    | tar -xz                                                                                                                                          \
   && mv doctl /dependencies/
 
 # Install github hub
 ARG HUB_VERSION=2.6.0
-RUN set -euxo pipefail; cd /opt/ \
-  && curl -L https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz \
-  | tar xzvf -                   \
+RUN set -euxo pipefail; curl -sL "https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz" \
+  | tar -xz                                                                                                                           \
   && mv ./hub-linux-amd64-*/bin/hub /dependencies/
 
 # Install AWS IAM authenticator for EKS
 ARG AWS_AUTHENTICATOR_VERSION=1.11.5
-RUN curl -o /dependencies/aws-iam-authenticator   \
-    https://amazon-eks.s3-us-west-2.amazonaws.com/${AWS_AUTHENTICATOR_VERSION}/2018-12-06/bin/linux/amd64/aws-iam-authenticator \
+RUN curl -sLo /dependencies/aws-iam-authenticator                                                                                 \
+    "https://amazon-eks.s3-us-west-2.amazonaws.com/${AWS_AUTHENTICATOR_VERSION}/2018-12-06/bin/linux/amd64/aws-iam-authenticator" \
   && chmod +x /dependencies/aws-iam-authenticator
 
 # Install notary
 ARG NOTARY_VERSION=0.6.1
-RUN curl -Lo /dependencies/notary                                                           \
-    https://github.com/theupdateframework/notary/releases/download/v${NOTARY_VERSION}/notary-Linux-amd64 \
+RUN curl -sLo /dependencies/notary                                                                         \
+    "https://github.com/theupdateframework/notary/releases/download/v${NOTARY_VERSION}/notary-Linux-amd64" \
   && chmod +x /dependencies/notary
 
 # Install docker-compose
 ARG DOCKER_COMPOSE_VERSION=1.24.0
-RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" \
-      -o /dependencies/docker-compose        \
+RUN curl -sLo /dependencies/docker-compose                                                                                 \
+    "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" \
     && chmod +x /dependencies/docker-compose
 
 # Install goss
 ARG GOSS_VERSION=0.3.7
-RUN curl -Lo /dependencies/goss                                                 \
-    https://github.com/aelsabbahy/goss/releases/download/v${GOSS_VERSION}/goss-linux-amd64 \
+RUN curl -sLo /dependencies/goss                                                             \
+    "https://github.com/aelsabbahy/goss/releases/download/v${GOSS_VERSION}/goss-linux-amd64" \
   && chmod +x /dependencies/goss
 
 # Install conftest
 ARG CONFTEST_VERSION=0.4.2
-RUN wget https://github.com/instrumenta/conftest/releases/download/v0.4.2/conftest_0.4.2_Linux_x86_64.tar.gz \
-  && tar xzf conftest_0.4.2_Linux_x86_64.tar.gz \
+RUN set -euxo pipefail; curl -sL "https://github.com/instrumenta/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
+  | tar -xz                                                                                                                                                        \
   && mv conftest /dependencies/
 
 #--------------------------#


### PR DESCRIPTION
I'd hoped this would be a refactor to make the image smaller, alas I can't do that without removing some dependencies.  We apt-get an enourmous number of things which is why the image is so large.  I did tidy things up a lot and standardised the way we're downloading and installing deps.

 I don't think the build is any slower nor the image any larger